### PR TITLE
Changes to allow maxResults to be updated

### DIFF
--- a/packages/components/nodes/agentflow/LLM/LLM.ts
+++ b/packages/components/nodes/agentflow/LLM/LLM.ts
@@ -897,7 +897,7 @@ class LLM_Agentflow implements INode {
         if (isStructuredOutput && typeof response === 'object') {
             const structuredOutput = response as Record<string, any>
             for (const key in structuredOutput) {
-                if (structuredOutput[key]) {
+                if (structuredOutput[key] !== undefined && structuredOutput[key] !== null) {
                     output[key] = structuredOutput[key]
                 }
             }

--- a/packages/components/nodes/tools/Jira/core.ts
+++ b/packages/components/nodes/tools/Jira/core.ts
@@ -213,8 +213,8 @@ class ListIssuesTool extends BaseJiraTool {
         }
 
         if (jql) queryParams.append('jql', jql)
-        if (params.maxResults) queryParams.append('maxResults', params.maxResults.toString())
-        if (params.startAt) queryParams.append('startAt', params.startAt.toString())
+        if (params.maxResults !== undefined && params.maxResults !== null) queryParams.append('maxResults', params.maxResults.toString())
+        if (params.startAt !== undefined && params.startAt !== null) queryParams.append('startAt', params.startAt.toString())
 
         const endpoint = `search?${queryParams.toString()}`
 
@@ -552,8 +552,8 @@ class ListCommentsTool extends BaseJiraTool {
         const params = { ...arg, ...this.defaultParams }
         const queryParams = new URLSearchParams()
 
-        if (params.maxResults) queryParams.append('maxResults', params.maxResults.toString())
-        if (params.startAt) queryParams.append('startAt', params.startAt.toString())
+        if (params.maxResults !== undefined && params.maxResults !== null) queryParams.append('maxResults', params.maxResults.toString())
+        if (params.startAt !== undefined && params.startAt !== null) queryParams.append('startAt', params.startAt.toString())
 
         const endpoint = `issue/${params.issueKey}/comment?${queryParams.toString()}`
 
@@ -774,8 +774,8 @@ class SearchUsersTool extends BaseJiraTool {
         const queryParams = new URLSearchParams()
 
         if (params.query) queryParams.append('query', params.query)
-        if (params.maxResults) queryParams.append('maxResults', params.maxResults.toString())
-        if (params.startAt) queryParams.append('startAt', params.startAt.toString())
+        if (params.maxResults !== undefined && params.maxResults !== null) queryParams.append('maxResults', params.maxResults.toString())
+        if (params.startAt !== undefined && params.startAt !== null) queryParams.append('startAt', params.startAt.toString())
 
         const endpoint = `user/search?${queryParams.toString()}`
 

--- a/packages/server/src/utils/buildAgentflow.ts
+++ b/packages/server/src/utils/buildAgentflow.ts
@@ -351,8 +351,14 @@ export const resolveVariables = async (
                         const formattedValue =
                             Array.isArray(variableValue) || (typeof variableValue === 'object' && variableValue !== null)
                                 ? JSON.stringify(variableValue)
-                                : String(variableValue)
-                        resolvedValue = resolvedValue.replace(match, formattedValue)
+                                : variableValue
+                        // If the resolved value is exactly the match, replace it directly
+                        if (resolvedValue === match) {
+                            resolvedValue = formattedValue
+                        } else {
+                            // Otherwise do a standard string‐replace
+                            resolvedValue = String(resolvedValue).replace(match, String(formattedValue))
+                        }
                         // Skip fallback logic
                         continue
                     }


### PR DESCRIPTION
While testing the Jira tool noticed that all data was being pulled back and needed to be able to set the maxResults to 0 this was being picked up as a string '0' instead